### PR TITLE
(Codex) Add implementation plan for graph-related classes

### DIFF
--- a/docs/design/implementation_plans/as_of_20250609.md
+++ b/docs/design/implementation_plans/as_of_20250609.md
@@ -1,0 +1,100 @@
+# Implementation Plan for Scope, Proc and Graph (2025-06-09)
+
+This document outlines the planned steps for implementing the three partially
+implemented core classes located in `src/tg/core`: `Scope`, `Proc` and
+`Graph`.  These classes currently provide only skeletal interfaces.  The goal is
+for them to correctly build and manage a directed execution graph composed of
+`Step` objects and the data exchanged between steps.
+
+The plan below follows the existing design notes in `docs/design` and keeps
+within the current prototype’s scope (single‑threaded execution, no scheduler or
+thread pool yet).
+
+## 1. `Scope`
+
+1. **Add constructors**
+   - Provide a default constructor that assigns a unique scope name (e.g. using a
+     static counter or UUID generator).
+   - Allow an explicit name to be passed in for cases where the caller wants a
+     deterministic prefix.
+2. **Expose a setter for the scope name**
+   - `void set_name(std::string)`; mainly for factory/test use.
+3. **Keep `name()` implementation**
+   - Return `m_name`.
+4. **Implement `visit(Proc&)`**
+   - Obtain all steps from the `Proc` and call `visit(Step&)` on each.
+5. **Implement `visit(Step&)`**
+   - Use `DataCallback` to traverse the step’s `StepData` objects.
+   - Delegate to `visit(StepData&)` for each item.
+6. **Implement `visit(StepData&)`**
+   - Simply set the `scope_name` of the `StepData` to `m_name`.
+   - Later phases may also register the data item with internal lists.
+
+## 2. `Proc`
+
+1. **Construction and destruction**
+   - Default construct an internal `Scope` instance.
+   - Optionally accept a scope name so that multiple procs can coexist with
+     predictable prefixes.
+2. **`add_step(StepPtr)`**
+   - Validate the pointer is non‑null, otherwise throw.
+   - Use a `DataCallback` to set the scope name on each `StepData` contained in
+     the step via the associated `Scope`.
+   - Store the step in `m_steps` for later graph assembly.
+   - No scheduling or key assignment happens here yet.
+3. **`get_steps()`**
+   - Copy `m_steps` into the output vector.  The caller may inspect or iterate
+     the collection.
+4. **Future hook for data unification**
+   - Keep a placeholder comment describing how matching `StepData` names inside
+     the proc will later be consolidated during graph compilation.
+
+## 3. `Graph`
+
+1. **Internal storage**
+   - Maintain:
+     - `std::vector<StepPtr> m_steps;`
+     - `std::vector<DataImplPtr> m_data;`
+     - `std::unordered_map<AccessKey, KeyInfo> m_keys;`
+     - `std::unordered_map<std::string, size_t> m_name_to_index;` mapping fully
+       qualified data names to indices in `m_data`.
+2. **`add_step(ScopePtr, StepPtr)`**
+   - Verify inputs are non‑null.
+   - Use `DataCallback` to visit each `StepData` in the step.
+   - Form the fully qualified data name from the scope name and the
+     `StepData`’s own name.
+   - If the name is new:
+     - Create a fresh `AccessKey` (monotonic counter).
+     - Create a new `DataImpl` with the type from the `StepData` and push it to
+       `m_data`.
+     - Store `{access_key, usage}` in the `DataImpl`’s key/usage list.
+     - Record the mapping in `m_name_to_index` and `m_keys`.
+   - If the name already exists:
+     - Locate the existing `DataImpl`.
+     - Check the type matches; throw on mismatch.
+     - Append a new key/usage pair to that `DataImpl`.
+   - Assign the generated access key back to the `StepData` and freeze its
+     metadata.
+   - Append the step to `m_steps`.
+3. **`finalize()`** (new helper method)
+   - After all steps have been added, construct an `ExecData` instance from
+     `m_data` and `m_keys`.
+   - This object will later be fed to `StepExecutor` for each step.
+4. **`execute_all()`** (simple sequential runner)
+   - For now, run each stored step through `StepExecutor` sequentially using the
+     shared `ExecData`.
+   - Concurrency, scheduling and barrier logic remain future work.
+
+## 4. Milestones
+
+1. **Compile‑time only**: Implement the classes and ensure they build with the
+   existing unit tests (`blur_step_testcase`, etc.).
+2. **Simple integration test**: Build a small proc with two steps that share a
+   data name and run it through `Graph::execute_all()` to verify data passing via
+   `ExecData` works.
+3. **Validation hooks** (later phase): integrate the DAG check and type
+   validator described in the design notes.
+4. **Thread pool and scheduler** (future work): once the single‑threaded graph is
+   functional, extend `Graph` with a scheduler and thread pool as noted in
+   `docs/design/historic_monologues/ai_planning_20250529_2244pm.md`.
+


### PR DESCRIPTION
## Summary
- document implementation plan for `Scope`, `Proc` and `Graph`

------
https://chatgpt.com/codex/tasks/task_e_6847c58ff954832faac2a3e0c8ec42c5