### PR TITLE
(Codex) (br-20250615) Fix ScopeStepIter equality logic

### DIFF
--- a/src/tg/core/details/scope_step_iter.cpp
+++ b/src/tg/core/details/scope_step_iter.cpp
@@ -67,60 +67,40 @@ bool ScopeStepIter::operator==(const ScopeStepIter& other) const
         return true;
     }
     /**
-     * @note
-     * Equality operator logic.
-     * 
-     * The primary concern is that loop sentinels must work reliably.
-     * The secondary concern is that, for usability, this iterator needs to work gracefully
-     * when the underlying container (which is append-only) is grown in size, and when
-     * the underlying container (as a weak ref) expires.
-     * 
-     * The equality operator for ScopeStepIter is defined as follows:
-     * (1) Iterators from the same container compare equal when their positions match or when both are past the container’s current size.
-     * (2) Iterators from different containers are never equal unless both are expired.
-     * (3) When one iterator is expired and the other is valid, they compare equal only if the valid iterator’s position is past its current size.
+     * @brief Two iterators are equal when they reference the same ScopeInfo and
+     * their positions are both past end or hold the same index. Expired
+     * iterators compare equal to each other and to any iterator whose position
+     * is past the current step count.
      */
+
     auto sp_this = m_wp_scopeinfo.lock();
     auto sp_other = other.m_wp_scopeinfo.lock();
-    if (!sp_this && !sp_other)
+
+    if (sp_this && sp_other)
     {
-        return true; // Both iterators are empty or expired.
-    }
-    else if (sp_this && sp_other)
-    {
-        if (sp_this != sp_other)
+        if (sp_this.get() != sp_other.get())
         {
-            // Different ScopeInfo instances, cannot be equal.
             return false;
         }
-        if (m_pos == other.m_pos)
+        size_t count = sp_this->step_count();
+        bool this_end = m_pos >= count;
+        bool other_end = other.m_pos >= count;
+        if (this_end && other_end)
         {
-            // Both iterators point to the same ScopeInfo and position.
-            // Either they are both valid, or they're both past-the-end.
-            return true; 
-        }
-        // Same instance, but we still need to perform bounds check.
-        size_t both_size = sp_this->step_count();
-        if (m_pos >= both_size && other.m_pos >= both_size)
-        {
-            // Both iterators are past-the-end.
             return true;
         }
-        // If they are not past-the-end, they are equal if and only if their positions match.
         return m_pos == other.m_pos;
     }
-    else if (sp_this)
+    else if (!sp_this && !sp_other)
     {
-        // The other iterator is expired or empty.
-        // The iterators are considered equal if and only if this one is past the end,
-        // which signifies that both are loop sentinels.
-        return this->detail_is_past_end(*sp_this);
+        return true;
     }
     else
     {
-        // This iterator is expired or empty, while the other is valid.
-        // The iterators are considered equal if and only if the other one is past the end.
-        return other.detail_is_past_end(*sp_other);
+        const ScopeInfo& ref = sp_this ? *sp_this : *sp_other;
+        size_t count = ref.step_count();
+        size_t pos = sp_this ? m_pos : other.m_pos;
+        return pos >= count;
     }
 #if defined(__cpp_lib_unreachable)
 #  if __cpp_lib_unreachable >= 202202L

--- a/src/tg/core/details/scope_step_iter.cpp
+++ b/src/tg/core/details/scope_step_iter.cpp
@@ -1,0 +1,155 @@
+#include "tg/core/details/scope_step_iter.hpp"
+#include "tg/core/scope_info.hpp"
+
+namespace tg::core::details
+{
+
+ScopeStepIter::ScopeStepIter()
+    : m_wp_scopeinfo()
+    , m_pos(npos)
+{}
+
+ScopeStepIter::ScopeStepIter(ScopeInfoPtr scopeinfo, size_t pos)
+    : m_wp_scopeinfo(scopeinfo)
+    , m_pos(pos)
+{}
+
+ScopeStepIter::~ScopeStepIter()
+{}
+
+ScopeStepIter::ScopeStepIter(const ScopeStepIter&) = default;
+ScopeStepIter::ScopeStepIter(ScopeStepIter&&) = default;
+ScopeStepIter& ScopeStepIter::operator=(const ScopeStepIter&) = default;
+ScopeStepIter& ScopeStepIter::operator=(ScopeStepIter&&) = default;
+
+ScopeStepIter ScopeStepIter::begin() const
+{
+    return ScopeStepIter(m_wp_scopeinfo.lock(), 0u);
+}
+
+ScopeStepIter ScopeStepIter::end() const
+{
+    auto sp_scopeinfo = m_wp_scopeinfo.lock();
+    if (!sp_scopeinfo)
+    {
+        return ScopeStepIter();
+    }
+    return ScopeStepIter(sp_scopeinfo, sp_scopeinfo->step_count());
+}
+
+StepPtr ScopeStepIter::operator*() const
+{
+    auto sp_scopeinfo = m_wp_scopeinfo.lock();
+    if (!sp_scopeinfo)
+    {
+        return nullptr;
+    }
+    return sp_scopeinfo->step_at(m_pos);
+}
+
+ScopeStepIter& ScopeStepIter::operator++()
+{
+    ++m_pos;
+    return *this;
+}
+
+ScopeStepIter ScopeStepIter::operator++(int)
+{
+    ScopeStepIter tmp(*this);
+    ++(*this);
+    return tmp;
+}
+
+bool ScopeStepIter::operator==(const ScopeStepIter& other) const
+{
+    if (this == &other)
+    {
+        return true;
+    }
+    /**
+     * @details Requirements:
+     * (1) If both iterators point to some valid ScopeInfo, and...
+     * (1.1) If the ScopeInfo pointers are equal (SAME INSTANCE, ...), and...
+     * (1.1.1) If the positions are equal, return true; no need to check bounds (IMPLIED (EITHER (BOTH GO, SAME POS) OR (BOTH STOP))). However...
+     * (1.1.2) If the positions are not equal, compare their positions to the ScopeInfo's step count. Then...
+     * (1.1.2.1) If both are out-of-bounds, return true (BOTH STOP). Otherwise...
+     * (1.1.2.2) Return true if their positions are equal (BOTH GO, SAME POS), false otherwise. (BOTH GO, DIFFERENT POS).
+     * (1.2) If their ScopeInfo pointers are not equal, return false (DIFFERENT INSTANCES).
+     * (2) If both iterators point to a null or expired ScopeInfo, return true (BOTH STOP).
+     * (3) If one iterator points to a valid ScopeInfo and the other to a null or expired ScopeInfo, ...
+     * (3...) (cont'd) On the iterator containing the valid ScopeInfo, compare its position to its step count. Then...
+     * (3...) (cont'd) If the position is out-of-bounds, return true (BOTH STOP). False otherwise.
+     */
+    throw std::runtime_error("ScopeStepIter::operator==(): Not implemented yet");
+#if 0 // DISABLED - POSSIBLY INCORRECT IMPLEMENTATION
+    // /**
+    //  * @note Logic table.
+    //  * 
+    //  * Shorthands.
+    //  * L for LHS (left-hand-side, or first argument to equality operator).
+    //  * R for RHS.
+    //  * Z for zero. (pointer null or expired)
+    //  * T for terminal. (pos >= size) (both are unsigned integers.)
+    //  * V for valid. (pointer valid, pos < size)
+    //  * PPE for all equal (both pointer and position).
+    //  * 
+    //  * Let:
+    //  * (1) LZ = LHS null/expire, (2) RZ = RHS null/expire,
+    //  * (3) LT = LHS past-end,    (4) RT = RHS past-end,
+    //  * (5) LV = LHS valid,       (6) RV = RHS valid.
+    //  * (7) PPE = (LHS valid) AND (RHS valid) AND (LHS.pos == RHS.pos)
+    //  * Given:
+    //  * (LV == true) <===> (LZ == false AND LQ == false)
+    //  * (RV == true) <===> ((RX OR RE) == false)
+    //  * (EqualityOperatorResult == true) <===> ((5 AND 6) OR ((1 OR 3) AND (2 or 4)))
+    //  */
+    // auto sp_this = m_wp_scopeinfo.lock();
+    // auto sp_other = other.m_wp_scopeinfo.lock();
+    // if (sp_this == sp_other && m_pos == other.m_pos)
+    // {
+    //     /**
+    //      * @note Both iterators point to the same ScopeInfo and position.
+    //      * Pas-end check is not needed here, because when all attributes 
+    //      * are equal, their past-end checks result will also be equal.
+    //      */
+    //     return true;
+    // }
+    // /**
+    //  * @note Past-end check with the already-locked ScopeInfo ptrs.
+    //  */
+    // bool this_past_end = this->detail_is_past_end(*sp_this);
+    // bool other_past_end = other.detail_is_past_end(*sp_other);
+    // if (this_past_end && other_past_end)
+    // {
+    //     // All past-end iterators (including containers expired or empty)
+    //     // are considered equal, because they act as sentinels to stop a
+    //     // for-loop.
+    //     // This is the case even if the underlying ScopeInfo addresses
+    //     // are different.
+    //     return true;
+    // }
+    // return (sp_this == sp_other && m_pos == other.m_pos);
+#endif // DISABLED - POSSIBLY INCORRECT IMPLEMENTATION
+}
+
+bool ScopeStepIter::operator!=(const ScopeStepIter& other) const
+{
+    return !(*this == other);
+}
+
+bool ScopeStepIter::is_past_end() const
+{
+    ScopeInfoPtr sp_info = m_wp_scopeinfo.lock();
+    if (!sp_info)
+    {
+        return true;
+    }
+    return this->detail_is_past_end(*sp_info);
+}
+
+bool ScopeStepIter::detail_is_past_end(const ScopeInfo& ref_info) const
+{
+    return m_pos >= ref_info.step_count();
+}
+
+} // namespace tg::core::details

--- a/src/tg/core/details/scope_step_iter.hpp
+++ b/src/tg/core/details/scope_step_iter.hpp
@@ -1,0 +1,81 @@
+#pragma once
+#include "tg/core/fwd.hpp"
+
+namespace tg::core::details
+{
+
+class ScopeStepIter
+{
+public:
+    static constexpr size_t npos = ~static_cast<size_t>(0u);
+
+public:
+    ScopeStepIter();
+    explicit ScopeStepIter(ScopeInfoPtr scopeinfo, size_t pos = 0u);
+    ~ScopeStepIter();
+    ScopeStepIter(const ScopeStepIter&);
+    ScopeStepIter(ScopeStepIter&&);
+    ScopeStepIter& operator=(const ScopeStepIter&);
+    ScopeStepIter& operator=(ScopeStepIter&&);
+
+public:
+    /**
+     * @brief Returns an iterator to the beginning of the Steps in the ScopeInfo.
+     * @returns A ScopeStepIter pointing to the first Step in the ScopeInfo.
+     */
+    ScopeStepIter begin() const;
+
+    /**
+     * @brief Returns an iterator to the end of the Steps in the ScopeInfo.
+     * @returns A ScopeStepIter pointing past the last Step in the ScopeInfo.
+     */
+    ScopeStepIter end() const;
+
+    /**
+     * @brief Dereference operator to get the Step at the current position.
+     * @returns A strong pointer to the Step at the current position,
+     * or an empty pointer if the position is out of bounds or if the
+     * ScopeInfo or Step is no longer valid.
+     */
+    StepPtr operator*() const;
+
+    /**
+     * @brief Pre-increment operator to move to the next Step.
+     * @returns A reference to the current ScopeStepIter after incrementing.
+     */
+    ScopeStepIter& operator++();
+
+    /**
+     * @brief Post-increment operator to move to the next Step.
+     * @returns A copy of the current ScopeStepIter before incrementing.
+     */
+    ScopeStepIter operator++(int);
+
+    /**
+     * @brief Equality operator to compare two ScopeStepIter objects.
+     * @returns True if both are valid and equal, or if both are invalid (past end).
+     */
+    bool operator==(const ScopeStepIter& other) const;
+
+    /**
+     * @brief Inequality operator to compare two ScopeStepIter objects.
+     */
+    bool operator!=(const ScopeStepIter& other) const;
+
+    /**
+     * @brief Checks if the iterator is past the end of the Steps in the ScopeInfo.
+     * @returns True if the current position is past the last Step in the ScopeInfo,
+     * or if the ScopeInfo is no longer valid.
+     */
+    [[nodiscard]]
+    bool is_past_end() const;
+
+private:
+    bool detail_is_past_end(const ScopeInfo& ref_info) const;
+
+private:
+    ScopeInfoWPtr m_wp_scopeinfo;
+    size_t m_pos;
+};
+
+} // namespace tg::core::details

--- a/src/tg/core/fwd.hpp
+++ b/src/tg/core/fwd.hpp
@@ -35,6 +35,7 @@ using StepInfoPtr = std::shared_ptr<StepInfo>;
 struct DataInfoTuple;
 
 class Scope;
+class ScopeIter;
 using ScopePtr = std::shared_ptr<Scope>;
 
 class ScopeInfo;

--- a/src/tg/core/fwd.hpp
+++ b/src/tg/core/fwd.hpp
@@ -42,4 +42,9 @@ class ScopeInfo;
 using ScopeInfoPtr = std::shared_ptr<ScopeInfo>;
 using ScopeInfoWPtr = std::weak_ptr<ScopeInfo>;
 
+namespace details
+{
+    class ScopeStepIter;    
+}
+
 } // namespace tg::core

--- a/src/tg/core/scope.cpp
+++ b/src/tg/core/scope.cpp
@@ -2,9 +2,12 @@
 #include "tg/core/scope_info.hpp"
 #include "tg/core/step.hpp"
 #include "tg/core/step_info.hpp"
+#include "tg/core/details/scope_step_iter.hpp"
 
 namespace tg::core
 {
+
+using ScopeStepIter = Scope::ScopeStepIter;
 
 Scope::Scope(std::string_view scopename)
     : m_scopename{scopename}
@@ -80,6 +83,31 @@ bool Scope::contains(StepPtr step) const
 std::vector<StepPtr> Scope::get_steps() const
 {
     return m_steps;
+}
+
+ScopeStepIter Scope::begin() const
+{
+    return ScopeStepIter(m_sp_scopeinfo, 0u);
+}
+
+ScopeStepIter Scope::end() const
+{
+    auto npos = ScopeStepIter::npos;
+    return ScopeStepIter(m_sp_scopeinfo, npos);
+}
+
+size_t Scope::step_count() const
+{
+    return m_steps.size();
+}
+
+StepPtr Scope::step_at(size_t index) const
+{
+    if (index > m_steps.size())
+    {
+        return nullptr;
+    }
+    return m_steps.at(index);
 }
 
 void Scope::freeze()

--- a/src/tg/core/scope.hpp
+++ b/src/tg/core/scope.hpp
@@ -1,80 +1,9 @@
 #pragma once
 #include "tg/core/fwd.hpp"
+#include "tg/core/details/scope_step_iter.hpp"
 
 namespace tg::core
 {
-
-class ScopeStepIter
-{
-public:
-    static constexpr size_t npos = ~static_cast<size_t>(0u);
-    ScopeStepIter()
-        : m_wp_scopeinfo()
-        , m_pos(npos)
-    {}
-    explicit ScopeStepIter(ScopeInfoPtr scopeinfo, size_t pos = 0u)
-        : m_wp_scopeinfo(scopeinfo)
-        , m_pos(pos)
-    {}
-    ~ScopeStepIter() = default;
-    ScopeStepIter(const ScopeStepIter&) = default;
-    ScopeStepIter(ScopeStepIter&&) = default;
-    ScopeStepIter& operator=(const ScopeStepIter&) = default;
-    ScopeStepIter& operator=(ScopeStepIter&&) = default;
-public:
-    ScopeStepIter& operator++()
-    {
-        ++m_pos;
-        return *this;
-    }
-    ScopeStepIter operator++(int)
-    {
-        ScopeIter tmp(*this);
-        ++(*this);
-        return tmp;
-    }
-    bool operator==(const ScopeStepIter& other) const
-    {
-        if (this == &other)
-        {
-            return true;
-        }
-        auto sp_this = m_wp_scopeinfo.lock();
-        auto sp_other = other.m_wp_scopeinfo.lock();
-        bool valid_this = (bool)sp_this;
-        bool valid_other = (bool)sp_other;
-        size_t this_size = valid_this ? sp_this->step_count() : 0u;
-        size_t other_size = valid_other ? sp_other->step_count() : 0u;
-        bool this_past_end = (m_pos >= this_size);
-        bool other_past_end = (other.m_pos >= other_size);
-        if (this_past_end && other_past_end)
-        {
-            // All past-end iterators (including containers expired or empty)
-            // are considered equal, because they act as sentinels to stop a
-            // for-loop.
-            // This is the case even if the underlying ScopeInfo addresses
-            // are different.
-            return true;
-        }
-        if (this_past_end || other_past_end)
-        {
-            return false;
-        }
-        if (!valid_this || !valid_other)
-        {
-            return false;
-        }
-        if (sp_this.get() != sp_other.get())
-        {
-            return false;
-        }
-        return (m_pos == other.m_pos);
-    }
-
-private:
-    ScopeInfoWPtr m_wp_scopeinfo;
-    size_t m_pos;
-};
 
 /**
  * @brief Scope acts as both a namespace and a collection of Steps.
@@ -92,6 +21,9 @@ private:
  */
 class Scope
 {
+public:
+    using ScopeStepIter = tg::core::details::ScopeStepIter;
+
 public:
     /**
      * @brief Initializes a Scope with a given name.
@@ -137,6 +69,27 @@ public:
      * @brief Gets all Steps belonging to the Scope.
      */
     std::vector<StepPtr> get_steps() const;
+
+    /**
+     * @brief Creates a begin-iterator for the steps.
+     */
+    ScopeStepIter begin() const;
+
+    /**
+     * @brief Creates an end-iterator for the steps.
+     */
+    ScopeStepIter end() const;
+
+    /**
+     * @brief Returns the number of Steps in the Scope.
+     */
+    size_t step_count() const;
+
+    /**
+     * @brief Read the Step at the specified index as a strong ref,
+     * or return an empty pointer if the index is out of bounds.
+     */
+    StepPtr step_at(size_t index) const;
 
     /**
      * @brief Freezes the NameScope as well as all Step objects added to it.

--- a/src/tg/core/scope_info.cpp
+++ b/src/tg/core/scope_info.cpp
@@ -30,6 +30,11 @@ void ScopeInfo::assert_owner_token(size_t owner_token) const
     }
 }
 
+size_t ScopeInfo::step_count() const
+{
+    return m_wp_steps.size();
+}
+
 void ScopeInfo::add_step(size_t owner_token, StepPtr step)
 {
     if (m_frozen)
@@ -49,6 +54,15 @@ void ScopeInfo::add_step(size_t owner_token, StepPtr step)
      * as in the owning Scope.
      */
     m_wp_steps.emplace_back(step);
+}
+
+StepPtr ScopeInfo::step_at(size_t index) const
+{
+    if (index >= m_wp_steps.size())
+    {
+        return StepPtr{};
+    }
+    return m_wp_steps.at(index).lock();
 }
 
 const std::string& ScopeInfo::scopename() const

--- a/src/tg/core/scope_info.hpp
+++ b/src/tg/core/scope_info.hpp
@@ -28,6 +28,11 @@ public:
     void assert_owner_token(size_t owner_token) const;
 
     /**
+     * @brief Returns the number of Steps in the ScopeInfo.
+     */
+    size_t step_count() const;
+
+    /**
      * @brief Stores a weak pointer to the Step in the ScopeInfo.
      * 
      * @param owner_token The token of the owner Scope, used for validation.
@@ -36,6 +41,12 @@ public:
      * @note This method converts the Step to a weak pointer for storage.
      */
     void add_step(size_t owner_token, StepPtr step);
+
+    /**
+     * @brief Read the Step at the specified index as a strong ref,
+     * or return an empty pointer if the index is out of bounds.
+     */
+    StepPtr step_at(size_t index) const;
 
     /**
      * @brief Retrieves the short name of the Scope.

--- a/src/tg/testcase/tg_testcase.cpp
+++ b/src/tg/testcase/tg_testcase.cpp
@@ -82,12 +82,11 @@ void tg_testcase_3(OStrm cout)
     scope.add(conncomp_step);
     scope.freeze();
     cout << "Scope name: " << scope.scopename() << std::endl;
-    auto steps = scope.get_steps();
-    size_t step_count = steps.size();
-    for (size_t step_index = 0u; step_index < step_count; ++step_index)
+    size_t next_step_index = 0u;
+    for (const auto& step : scope)
     {
+        size_t step_index = next_step_index++;
         cout << "Step " << step_index << " in Scope '" << scope.scopename() << "':" << std::endl; 
-        auto& step = steps.at(step_index);
         print_step_summary(*step, cout);
     }
     cout << "tg_testcase_3 success." << std::endl;

--- a/tests/scope_step_iter_test.cpp
+++ b/tests/scope_step_iter_test.cpp
@@ -1,0 +1,53 @@
+#include <cassert>
+#include "tg/core/scope.hpp"
+#include "tg/core/step.hpp"
+#include "tg/core/step_info.hpp"
+
+using namespace tg::core;
+
+struct DummyStep : Step
+{
+    DummyStep() : Step(std::make_shared<StepInfo>("Dummy")) {}
+    void execute(std::vector<VarData>&) override {}
+};
+
+int main()
+{
+    // Create scope and add one step
+    Scope scope("S");
+    auto s1 = std::make_shared<DummyStep>();
+    scope.add(s1);
+
+    // Capture iterators before modifying the scope
+    auto it_begin_before = scope.begin();
+    auto it_end_before = scope.end();
+
+    // Grow the scope
+    auto s2 = std::make_shared<DummyStep>();
+    scope.add(s2);
+
+    auto it_end_after = scope.end();
+
+    // Old end iterator should compare equal to new end iterator
+    assert(it_end_before == it_end_after);
+
+    // Increment iterator captured before growth
+    auto iter = it_begin_before;
+    ++iter;                   // now at index 1
+    assert(iter != it_end_after);
+    ++iter;                   // now past end
+    assert(iter == it_end_after);
+
+    // Expired iterators compare equal
+    ScopeStepIter expired_begin;
+    ScopeStepIter expired_end;
+    {
+        Scope tmp("Tmp");
+        tmp.add(std::make_shared<DummyStep>());
+        expired_begin = tmp.begin();
+        expired_end = tmp.end();
+    } // tmp destroyed
+    assert(expired_begin == expired_end);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement equality semantics for ScopeStepIter
- test comparisons after scope growth and expiration

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "OpenCV")*

## Design process

Links to previous discussions (OpenAI Codex):

https://chatgpt.com/s/cd_684f84f6f6248191930491ec17cf94b7
https://chatgpt.com/s/cd_684f850675a8819183ecac8d2eb4cbe2

------
https://chatgpt.com/codex/tasks/task_e_684f7ff6f698832fb52b285bd94e3552