### PR TITLE
ScopeStepIter (iterates Steps stored in Scope)

### DIFF
--- a/src/tg/core/details/scope_step_iter.cpp
+++ b/src/tg/core/details/scope_step_iter.cpp
@@ -49,6 +49,11 @@ StepPtr ScopeStepIter::operator*() const
 
 ScopeStepIter& ScopeStepIter::operator++()
 {
+    if (m_pos == npos)
+    {
+        throw std::overflow_error("ScopeStepIter::operator++() "
+            "bad attempt to increment an end-iterator.");
+    }
     ++m_pos;
     return *this;
 }

--- a/src/tg/core/details/scope_step_iter.cpp
+++ b/src/tg/core/details/scope_step_iter.cpp
@@ -1,0 +1,155 @@
+#include "tg/core/details/scope_step_iter.hpp"
+#include "tg/core/scope_info.hpp"
+
+namespace tg::core::details
+{
+
+ScopeStepIter::ScopeStepIter()
+    : m_wp_scopeinfo()
+    , m_pos(npos)
+{}
+
+ScopeStepIter::ScopeStepIter(ScopeInfoPtr scopeinfo, size_t pos)
+    : m_wp_scopeinfo(scopeinfo)
+    , m_pos(pos)
+{}
+
+ScopeStepIter::~ScopeStepIter()
+{}
+
+ScopeStepIter::ScopeStepIter(const ScopeStepIter&) = default;
+ScopeStepIter::ScopeStepIter(ScopeStepIter&&) = default;
+ScopeStepIter& ScopeStepIter::operator=(const ScopeStepIter&) = default;
+ScopeStepIter& ScopeStepIter::operator=(ScopeStepIter&&) = default;
+
+ScopeStepIter ScopeStepIter::begin() const
+{
+    return ScopeStepIter(m_wp_scopeinfo.lock(), 0u);
+}
+
+ScopeStepIter ScopeStepIter::end() const
+{
+    auto sp_scopeinfo = m_wp_scopeinfo.lock();
+    if (!sp_scopeinfo)
+    {
+        return ScopeStepIter();
+    }
+    return ScopeStepIter(sp_scopeinfo, sp_scopeinfo->step_count());
+}
+
+StepPtr ScopeStepIter::operator*() const
+{
+    auto sp_scopeinfo = m_wp_scopeinfo.lock();
+    if (!sp_scopeinfo)
+    {
+        return nullptr;
+    }
+    return sp_scopeinfo->step_at(m_pos);
+}
+
+ScopeStepIter& ScopeStepIter::operator++()
+{
+    ++m_pos;
+    return *this;
+}
+
+ScopeStepIter ScopeStepIter::operator++(int)
+{
+    ScopeStepIter tmp(*this);
+    ++(*this);
+    return tmp;
+}
+
+bool ScopeStepIter::operator==(const ScopeStepIter& other) const
+{
+    if (this == &other)
+    {
+        return true;
+    }
+    /**
+     * @details Requirements:
+     * (1) If both iterators point to some valid ScopeInfo, and...
+     * (1.1) If the ScopeInfo pointers are equal (SAME INSTANCE, ...), and...
+     * (1.1.1) If the positions are equal, return true; no need to check bounds (IMPLIED (EITHER (BOTH GO, SAME POS) OR (BOTH STOP))). However...
+     * (1.1.2) If the positions are not equal, compare their positions to the ScopeInfo's step count. Then...
+     * (1.1.2.1) If both are out-of-bounds, return true (BOTH STOP). Otherwise...
+     * (1.1.2.2) Return true if their positions are equal (BOTH GO, SAME POS), false otherwise. (BOTH GO, DIFFERENT POS).
+     * (1.2) If their ScopeInfo pointers are not equal, return false (DIFFERENT INSTANCES).
+     * (2) If both iterators point to a null or expired ScopeInfo, return true (BOTH STOP).
+     * (3) If one iterator points to a valid ScopeInfo and the other to a null or expired ScopeInfo, ...
+     * (3...) (cont'd) On the iterator containing the valid ScopeInfo, compare its position to its step count. Then...
+     * (3...) (cont'd) If the position is out-of-bounds, return true (BOTH STOP). False otherwise.
+     */
+    throw std::runtime_error("ScopeStepIter::operator==(): Not implemented yet");
+#if 0 // DISABLED - POSSIBLY INCORRECT IMPLEMENTATION
+    // /**
+    //  * @note Logic table.
+    //  * 
+    //  * Shorthands.
+    //  * L for LHS (left-hand-side, or first argument to equality operator).
+    //  * R for RHS.
+    //  * Z for zero. (pointer null or expired)
+    //  * T for terminal. (pos >= size) (both are unsigned integers.)
+    //  * V for valid. (pointer valid, pos < size)
+    //  * PPE for all equal (both pointer and position).
+    //  * 
+    //  * Let:
+    //  * (1) LZ = LHS null/expire, (2) RZ = RHS null/expire,
+    //  * (3) LT = LHS past-end,    (4) RT = RHS past-end,
+    //  * (5) LV = LHS valid,       (6) RV = RHS valid.
+    //  * (7) PPE = (LHS valid) AND (RHS valid) AND (LHS.pos == RHS.pos)
+    //  * Given:
+    //  * (LV == true) <===> (LZ == false AND LQ == false)
+    //  * (RV == true) <===> ((RX OR RE) == false)
+    //  * (EqualityOperatorResult == true) <===> ((5 AND 6) OR ((1 OR 3) AND (2 or 4)))
+    //  */
+    // auto sp_this = m_wp_scopeinfo.lock();
+    // auto sp_other = other.m_wp_scopeinfo.lock();
+    // if (sp_this == sp_other && m_pos == other.m_pos)
+    // {
+    //     /**
+    //      * @note Both iterators point to the same ScopeInfo and position.
+    //      * Pas-end check is not needed here, because when all attributes 
+    //      * are equal, their past-end checks result will also be equal.
+    //      */
+    //     return true;
+    // }
+    // /**
+    //  * @note Past-end check with the already-locked ScopeInfo ptrs.
+    //  */
+    // bool this_past_end = this->detail_is_past_end(*sp_this);
+    // bool other_past_end = other.detail_is_past_end(*sp_other);
+    // if (this_past_end && other_past_end)
+    // {
+    //     // All past-end iterators (including containers expired or empty)
+    //     // are considered equal, because they act as sentinels to stop a
+    //     // for-loop.
+    //     // This is the case even if the underlying ScopeInfo addresses
+    //     // are different.
+    //     return true;
+    // }
+    // return (sp_this == sp_other && m_pos == other.m_pos);
+#endif // DISABLED - POSSIBLY INCORRECT IMPLEMENTATION
+}
+
+bool ScopeStepIter::operator!=(const ScopeStepIter& other) const
+{
+    return !(*this == other);
+}
+
+bool ScopeStepIter::is_past_end() const
+{
+    ScopeInfoPtr sp_info = m_wp_scopeinfo.lock();
+    if (!sp_info)
+    {
+        return true;
+    }
+    return this->detail_is_past_end(*sp_info);
+}
+
+bool ScopeStepIter::detail_is_past_end(const ScopeInfo& ref_info) const
+{
+    return m_pos >= ref_info.step_count();
+}
+
+} // namespace tg::core::details

--- a/src/tg/core/details/scope_step_iter.hpp
+++ b/src/tg/core/details/scope_step_iter.hpp
@@ -1,0 +1,81 @@
+#pragma once
+#include "tg/core/fwd.hpp"
+
+namespace tg::core::details
+{
+
+class ScopeStepIter
+{
+public:
+    static constexpr size_t npos = ~static_cast<size_t>(0u);
+
+public:
+    ScopeStepIter();
+    explicit ScopeStepIter(ScopeInfoPtr scopeinfo, size_t pos = 0u);
+    ~ScopeStepIter();
+    ScopeStepIter(const ScopeStepIter&);
+    ScopeStepIter(ScopeStepIter&&);
+    ScopeStepIter& operator=(const ScopeStepIter&);
+    ScopeStepIter& operator=(ScopeStepIter&&);
+
+public:
+    /**
+     * @brief Returns an iterator to the beginning of the Steps in the ScopeInfo.
+     * @returns A ScopeStepIter pointing to the first Step in the ScopeInfo.
+     */
+    ScopeStepIter begin() const;
+
+    /**
+     * @brief Returns an iterator to the end of the Steps in the ScopeInfo.
+     * @returns A ScopeStepIter pointing past the last Step in the ScopeInfo.
+     */
+    ScopeStepIter end() const;
+
+    /**
+     * @brief Dereference operator to get the Step at the current position.
+     * @returns A strong pointer to the Step at the current position,
+     * or an empty pointer if the position is out of bounds or if the
+     * ScopeInfo or Step is no longer valid.
+     */
+    StepPtr operator*() const;
+
+    /**
+     * @brief Pre-increment operator to move to the next Step.
+     * @returns A reference to the current ScopeStepIter after incrementing.
+     */
+    ScopeStepIter& operator++();
+
+    /**
+     * @brief Post-increment operator to move to the next Step.
+     * @returns A copy of the current ScopeStepIter before incrementing.
+     */
+    ScopeStepIter operator++(int);
+
+    /**
+     * @brief Equality operator to compare two ScopeStepIter objects.
+     * @returns True if both are valid and equal, or if both are invalid (past end).
+     */
+    bool operator==(const ScopeStepIter& other) const;
+
+    /**
+     * @brief Inequality operator to compare two ScopeStepIter objects.
+     */
+    bool operator!=(const ScopeStepIter& other) const;
+
+    /**
+     * @brief Checks if the iterator is past the end of the Steps in the ScopeInfo.
+     * @returns True if the current position is past the last Step in the ScopeInfo,
+     * or if the ScopeInfo is no longer valid.
+     */
+    [[nodiscard]]
+    bool is_past_end() const;
+
+private:
+    bool detail_is_past_end(const ScopeInfo& ref_info) const;
+
+private:
+    ScopeInfoWPtr m_wp_scopeinfo;
+    size_t m_pos;
+};
+
+} // namespace tg::core::details

--- a/src/tg/core/fwd.hpp
+++ b/src/tg/core/fwd.hpp
@@ -35,6 +35,7 @@ using StepInfoPtr = std::shared_ptr<StepInfo>;
 struct DataInfoTuple;
 
 class Scope;
+class ScopeIter;
 using ScopePtr = std::shared_ptr<Scope>;
 
 class ScopeInfo;

--- a/src/tg/core/fwd.hpp
+++ b/src/tg/core/fwd.hpp
@@ -42,4 +42,9 @@ class ScopeInfo;
 using ScopeInfoPtr = std::shared_ptr<ScopeInfo>;
 using ScopeInfoWPtr = std::weak_ptr<ScopeInfo>;
 
+namespace details
+{
+    class ScopeStepIter;    
+}
+
 } // namespace tg::core

--- a/src/tg/core/fwd.hpp
+++ b/src/tg/core/fwd.hpp
@@ -35,16 +35,12 @@ using StepInfoPtr = std::shared_ptr<StepInfo>;
 struct DataInfoTuple;
 
 class Scope;
-class ScopeIter;
 using ScopePtr = std::shared_ptr<Scope>;
 
 class ScopeInfo;
 using ScopeInfoPtr = std::shared_ptr<ScopeInfo>;
 using ScopeInfoWPtr = std::weak_ptr<ScopeInfo>;
 
-namespace details
-{
-    class ScopeStepIter;    
-}
+namespace details { class ScopeStepIter; }
 
 } // namespace tg::core

--- a/src/tg/core/scope.cpp
+++ b/src/tg/core/scope.cpp
@@ -103,7 +103,7 @@ size_t Scope::step_count() const
 
 StepPtr Scope::step_at(size_t index) const
 {
-    if (index > m_steps.size())
+    if (index >= m_steps.size())
     {
         return nullptr;
     }

--- a/src/tg/core/scope.cpp
+++ b/src/tg/core/scope.cpp
@@ -2,9 +2,12 @@
 #include "tg/core/scope_info.hpp"
 #include "tg/core/step.hpp"
 #include "tg/core/step_info.hpp"
+#include "tg/core/details/scope_step_iter.hpp"
 
 namespace tg::core
 {
+
+using ScopeStepIter = Scope::ScopeStepIter;
 
 Scope::Scope(std::string_view scopename)
     : m_scopename{scopename}
@@ -80,6 +83,31 @@ bool Scope::contains(StepPtr step) const
 std::vector<StepPtr> Scope::get_steps() const
 {
     return m_steps;
+}
+
+ScopeStepIter Scope::begin() const
+{
+    return ScopeStepIter(m_sp_scopeinfo, 0u);
+}
+
+ScopeStepIter Scope::end() const
+{
+    auto npos = ScopeStepIter::npos;
+    return ScopeStepIter(m_sp_scopeinfo, npos);
+}
+
+size_t Scope::step_count() const
+{
+    return m_steps.size();
+}
+
+StepPtr Scope::step_at(size_t index) const
+{
+    if (index > m_steps.size())
+    {
+        return nullptr;
+    }
+    return m_steps.at(index);
 }
 
 void Scope::freeze()

--- a/src/tg/core/scope.hpp
+++ b/src/tg/core/scope.hpp
@@ -1,80 +1,9 @@
 #pragma once
 #include "tg/core/fwd.hpp"
+#include "tg/core/details/scope_step_iter.hpp"
 
 namespace tg::core
 {
-
-class ScopeStepIter
-{
-public:
-    static constexpr size_t npos = ~static_cast<size_t>(0u);
-    ScopeStepIter()
-        : m_wp_scopeinfo()
-        , m_pos(npos)
-    {}
-    explicit ScopeStepIter(ScopeInfoPtr scopeinfo, size_t pos = 0u)
-        : m_wp_scopeinfo(scopeinfo)
-        , m_pos(pos)
-    {}
-    ~ScopeStepIter() = default;
-    ScopeStepIter(const ScopeStepIter&) = default;
-    ScopeStepIter(ScopeStepIter&&) = default;
-    ScopeStepIter& operator=(const ScopeStepIter&) = default;
-    ScopeStepIter& operator=(ScopeStepIter&&) = default;
-public:
-    ScopeStepIter& operator++()
-    {
-        ++m_pos;
-        return *this;
-    }
-    ScopeStepIter operator++(int)
-    {
-        ScopeIter tmp(*this);
-        ++(*this);
-        return tmp;
-    }
-    bool operator==(const ScopeStepIter& other) const
-    {
-        if (this == &other)
-        {
-            return true;
-        }
-        auto sp_this = m_wp_scopeinfo.lock();
-        auto sp_other = other.m_wp_scopeinfo.lock();
-        bool valid_this = (bool)sp_this;
-        bool valid_other = (bool)sp_other;
-        size_t this_size = valid_this ? sp_this->step_count() : 0u;
-        size_t other_size = valid_other ? sp_other->step_count() : 0u;
-        bool this_past_end = (m_pos >= this_size);
-        bool other_past_end = (other.m_pos >= other_size);
-        if (this_past_end && other_past_end)
-        {
-            // All past-end iterators (including containers expired or empty)
-            // are considered equal, because they act as sentinels to stop a
-            // for-loop.
-            // This is the case even if the underlying ScopeInfo addresses
-            // are different.
-            return true;
-        }
-        if (this_past_end || other_past_end)
-        {
-            return false;
-        }
-        if (!valid_this || !valid_other)
-        {
-            return false;
-        }
-        if (sp_this.get() != sp_other.get())
-        {
-            return false;
-        }
-        return (m_pos == other.m_pos);
-    }
-
-private:
-    ScopeInfoWPtr m_wp_scopeinfo;
-    size_t m_pos;
-};
 
 /**
  * @brief Scope acts as both a namespace and a collection of Steps.
@@ -92,6 +21,9 @@ private:
  */
 class Scope
 {
+public:
+    using ScopeStepIter = tg::core::details::ScopeStepIter;
+
 public:
     /**
      * @brief Initializes a Scope with a given name.
@@ -137,6 +69,27 @@ public:
      * @brief Gets all Steps belonging to the Scope.
      */
     std::vector<StepPtr> get_steps() const;
+
+    /**
+     * @brief Creates a begin-iterator for the steps.
+     */
+    ScopeStepIter begin() const;
+
+    /**
+     * @brief Creates an end-iterator for the steps.
+     */
+    ScopeStepIter end() const;
+
+    /**
+     * @brief Returns the number of Steps in the Scope.
+     */
+    size_t step_count() const;
+
+    /**
+     * @brief Read the Step at the specified index as a strong ref,
+     * or return an empty pointer if the index is out of bounds.
+     */
+    StepPtr step_at(size_t index) const;
 
     /**
      * @brief Freezes the NameScope as well as all Step objects added to it.

--- a/src/tg/core/scope_info.cpp
+++ b/src/tg/core/scope_info.cpp
@@ -30,6 +30,11 @@ void ScopeInfo::assert_owner_token(size_t owner_token) const
     }
 }
 
+size_t ScopeInfo::step_count() const
+{
+    return m_wp_steps.size();
+}
+
 void ScopeInfo::add_step(size_t owner_token, StepPtr step)
 {
     if (m_frozen)
@@ -49,6 +54,15 @@ void ScopeInfo::add_step(size_t owner_token, StepPtr step)
      * as in the owning Scope.
      */
     m_wp_steps.emplace_back(step);
+}
+
+StepPtr ScopeInfo::step_at(size_t index) const
+{
+    if (index >= m_wp_steps.size())
+    {
+        return StepPtr{};
+    }
+    return m_wp_steps.at(index).lock();
 }
 
 const std::string& ScopeInfo::scopename() const

--- a/src/tg/core/scope_info.hpp
+++ b/src/tg/core/scope_info.hpp
@@ -28,6 +28,11 @@ public:
     void assert_owner_token(size_t owner_token) const;
 
     /**
+     * @brief Returns the number of Steps in the ScopeInfo.
+     */
+    size_t step_count() const;
+
+    /**
      * @brief Stores a weak pointer to the Step in the ScopeInfo.
      * 
      * @param owner_token The token of the owner Scope, used for validation.
@@ -36,6 +41,12 @@ public:
      * @note This method converts the Step to a weak pointer for storage.
      */
     void add_step(size_t owner_token, StepPtr step);
+
+    /**
+     * @brief Read the Step at the specified index as a strong ref,
+     * or return an empty pointer if the index is out of bounds.
+     */
+    StepPtr step_at(size_t index) const;
 
     /**
      * @brief Retrieves the short name of the Scope.

--- a/src/tg/testcase/scope_step_iter_testcase.cpp
+++ b/src/tg/testcase/scope_step_iter_testcase.cpp
@@ -1,0 +1,138 @@
+#include <iostream>
+#include <string>
+#include <functional>
+#include "tg/core/fwd.hpp"
+#include "tg/core/step.hpp"
+#include "tg/core/step_info.hpp"
+#include "tg/core/scope.hpp"
+#include "tg/core/scope_info.hpp"
+#include "tg/common/project_macros.hpp"
+#include "tg/testcase/ostrm.hpp"
+
+using namespace tg::core;
+
+class DummyStep : public Step
+{
+public:
+    DummyStep(std::string_view name) : Step{} {
+        this->info().set_shortname(name);
+    }
+    void execute(std::vector<VarData>& data) {}
+};
+
+class WeakExpiryChecker
+{
+public:
+    WeakExpiryChecker() = default;
+    ~WeakExpiryChecker() = default;
+    template <typename T>
+    void add(std::shared_ptr<T> wp)
+    {
+        m_wps.push_back(wp);
+    }
+    void assert_all_expired(OStrm& cout) const
+    {
+        for (const auto& wp : m_wps)
+        {
+            auto sp = wp.lock();
+            if (sp)
+            {
+                throw std::runtime_error("WeakExpiryChecker: at least one weak pointer has not expired.");
+            }
+        }
+        cout << "WeakExpiryChecker success: all weak pointers are expired as expected." << std::endl;
+    }
+private:
+    std::vector<std::weak_ptr<void>> m_wps;
+};
+
+void scope_step_iter_testcase_1(OStrm cout, WeakExpiryChecker& wp_checker)
+{
+    cout << "====== BEGIN scope_step_iter_testcase_1 ======" << std::endl;
+    auto a = std::make_shared<DummyStep>("a");
+    wp_checker.add(a);
+    auto b = std::make_shared<DummyStep>("b");
+    wp_checker.add(b);
+    auto c = std::make_shared<DummyStep>("c");
+    wp_checker.add(c);
+    auto d = std::make_shared<DummyStep>("d");
+    wp_checker.add(d);
+    auto e = std::make_shared<DummyStep>("e");
+    wp_checker.add(e);
+    auto f = std::make_shared<DummyStep>("f");
+    wp_checker.add(f);
+    auto scope_zero = std::make_shared<Scope>("scope_zero");
+    wp_checker.add(scope_zero);
+    auto scope_one = std::make_shared<Scope>("scope_one");
+    wp_checker.add(scope_one);
+    auto scope_two = std::make_shared<Scope>("scope_two");
+    wp_checker.add(scope_two);
+    auto scope_three = std::make_shared<Scope>("scope_two");
+    wp_checker.add(scope_three);
+    scope_one->add(a);
+    scope_two->add(b);
+    scope_two->add(c);
+    scope_three->add(d);
+    scope_three->add(e);
+    scope_three->add(f);
+    auto begin_zero = scope_zero->begin();
+    auto end_zero = scope_zero->end();
+    auto begin_one = scope_one->begin();
+    auto end_one = scope_one->end();
+    auto begin_two = scope_two->begin();
+    auto end_two = scope_two->end();
+    auto begin_three = scope_three->begin();
+    auto end_three = scope_three->end();
+    auto iters = {
+        begin_zero, end_zero, begin_one, end_one, begin_two, end_two, begin_three, end_three
+    };
+    for (const auto& lhs : iters)
+    {
+        for (const auto& rhs : iters)
+        {
+            bool result = (lhs == rhs);
+            cout << (result ? "T" : "F") << " ";
+        }
+        cout << std::endl;
+    }
+    //
+    size_t count_zero = 0u;
+    for (auto iter = begin_zero; iter != end_zero; ++iter)
+    {
+        ++count_zero;
+    }
+    cout << "count_zero = " << count_zero << std::endl;
+    //
+    size_t count_one = 0u;
+    for (auto iter = begin_one; iter != end_one; ++iter)
+    {
+        ++count_one;
+    }
+    cout << "count_one = " << count_one << std::endl;
+    //
+    size_t count_two = 0u;
+    for (auto iter = begin_two; iter != end_two; ++iter)
+    {
+        ++count_two;
+    }
+    cout << "count_two = " << count_two << std::endl;
+    //
+    size_t count_three = 0u;
+    for (auto iter = begin_three; iter != end_three; ++iter)
+    {
+        ++count_three;
+    }
+    cout << "count_three = " << count_three << std::endl;
+    //
+    cout << "====== END scope_step_iter_testcase_1 ======" << std::endl;
+}
+
+void scope_step_iter_testcase()
+{
+    OStrm cout;
+    cout << "===== BEGIN scope_step_iter_testcase ======" << std::endl;
+    WeakExpiryChecker wp_checker_1;
+    scope_step_iter_testcase_1(cout, wp_checker_1);
+    wp_checker_1.assert_all_expired(cout);
+    cout << "===== END scope_step_iter_testcase ======" << std::endl;
+}

--- a/src/tg/testcase/scope_step_iter_testcase.cpp
+++ b/src/tg/testcase/scope_step_iter_testcase.cpp
@@ -67,7 +67,7 @@ void scope_step_iter_testcase_1(OStrm cout, WeakExpiryChecker& wp_checker)
     wp_checker.add(scope_one);
     auto scope_two = std::make_shared<Scope>("scope_two");
     wp_checker.add(scope_two);
-    auto scope_three = std::make_shared<Scope>("scope_two");
+    auto scope_three = std::make_shared<Scope>("scope_three");
     wp_checker.add(scope_three);
     scope_one->add(a);
     scope_two->add(b);
@@ -127,6 +127,52 @@ void scope_step_iter_testcase_1(OStrm cout, WeakExpiryChecker& wp_checker)
     cout << "====== END scope_step_iter_testcase_1 ======" << std::endl;
 }
 
+void scope_step_iter_testcase_2(OStrm cout)
+{
+    cout << "====== BEGIN scope_step_iter_testcase_2 ======" << std::endl;
+    auto scope_one = std::make_shared<Scope>("scope_one");
+    auto a = std::make_shared<DummyStep>("a");
+    scope_one->add(a);
+    auto begin_iter = scope_one->begin();
+    auto end_iter = scope_one->end();
+    auto begin_iter_to_increment = begin_iter;
+    try
+    {
+        ++begin_iter_to_increment;
+    }
+    catch (std::exception& ex)
+    {
+        cout << "Incrementing begin-iter (step_count == 1) Failed: expects no exception, but actually throwed." << std::endl;
+        cout << ex.what() << std::endl;
+    }
+    if (begin_iter_to_increment == begin_iter)
+    {
+        cout << "Incrementing begin-iter (step_count == 1) Failed: after incrementing, should not compare equal with the original begin iter." << std::endl;
+    }
+    if (begin_iter_to_increment != end_iter)
+    {
+        cout << "Incrementing begin-iter (step_count == 1) Failed: after incrementing, should compare equal with the end iter." << std::endl;
+    }
+    auto end_iter_to_increment = end_iter;
+    try
+    {
+        ++end_iter_to_increment;
+        // If this line is reached, it's failure.
+        cout << "Incrementing end-iter Failed: Expects exception to be throw, but actually not." << std::endl;
+    }
+    catch (std::exception& ex)
+    {
+        cout << "Incrementing end-iter works as expected: exception is thrown and caught. For reference, here is the message:" << std::endl;
+        cout << "\t" << ex.what() << std::endl;
+    }
+    // After catching the exception , the "invalidly increment" end-iter should remain unchanged, 
+    // i.e. it should still compare equal to the original end-iter, and should still act as a sentinel.
+    if (end_iter_to_increment != end_iter)
+    {
+        cout << "Incrementing end-iter Failed: after the invalid increment attempt threw and caught, expects the end-iter to remain unchanged." << std::endl;
+    }
+}
+
 void scope_step_iter_testcase()
 {
     OStrm cout;
@@ -134,5 +180,7 @@ void scope_step_iter_testcase()
     WeakExpiryChecker wp_checker_1;
     scope_step_iter_testcase_1(cout, wp_checker_1);
     wp_checker_1.assert_all_expired(cout);
+    //
+    scope_step_iter_testcase_2(cout);
     cout << "===== END scope_step_iter_testcase ======" << std::endl;
 }

--- a/src/tg/testcase/testcases.hpp
+++ b/src/tg/testcase/testcases.hpp
@@ -6,3 +6,4 @@ void vardata_testcase();
 void tg_testcase();
 void opaque_subindex_testcase();
 void opaque_ptr_key_testcase();
+void scope_step_iter_testcase();

--- a/src/tg/testcase/tg_testcase.cpp
+++ b/src/tg/testcase/tg_testcase.cpp
@@ -82,12 +82,11 @@ void tg_testcase_3(OStrm cout)
     scope.add(conncomp_step);
     scope.freeze();
     cout << "Scope name: " << scope.scopename() << std::endl;
-    auto steps = scope.get_steps();
-    size_t step_count = steps.size();
-    for (size_t step_index = 0u; step_index < step_count; ++step_index)
+    size_t next_step_index = 0u;
+    for (const auto& step : scope)
     {
+        size_t step_index = next_step_index++;
         cout << "Step " << step_index << " in Scope '" << scope.scopename() << "':" << std::endl; 
-        auto& step = steps.at(step_index);
         print_step_summary(*step, cout);
     }
     cout << "tg_testcase_3 success." << std::endl;


### PR DESCRIPTION
Helps simplify code by not requiring index-based iteration when visiting all Steps stored in a Scope.

Added test function ```scope_step_iter_testcase.cpp```