### PR TITLE
(Codex) Implement DataList indexing and equivalence

### DIFF
--- a/src/tg/core/dag/data_list.cpp
+++ b/src/tg/core/dag/data_list.cpp
@@ -3,15 +3,111 @@
 #include "tg/core/step_info.hpp"
 #include "tg/core/scope.hpp"
 #include "tg/core/scope_info.hpp"
-#include "tg/core/data_info_tuple.hpp" // as returned from StepInfo.
+#include "tg/core/data_info_tuple.hpp" // as returned from StepInfo
 
 namespace tg::core::dag
 {
 
 DataList::DataList()
+    : m_equivset(std::make_shared<EquivSet>())
 {}
 
-DataList::~DataList()
-{}
+DataList::~DataList() = default;
+
+size_t DataList::find_scope_index(ScopeInfoPtr scopeinfo) const
+{
+    if (!scopeinfo)
+    {
+        return static_cast<size_t>(-1);
+    }
+    for (size_t i = 0; i < m_scopes.size(); ++i)
+    {
+        if (&m_scopes.at(i)->info() == scopeinfo.get())
+        {
+            return i;
+        }
+    }
+    return static_cast<size_t>(-1);
+}
+
+void DataList::add_scope(ScopePtr scope)
+{
+    if (!scope)
+    {
+        throw std::invalid_argument("DataList::add_scope(): null scope");
+    }
+    m_scopes.push_back(scope);
+    auto steps = scope->get_steps();
+    for (const auto& step : steps)
+    {
+        this->add_step(step);
+    }
+}
+
+void DataList::add_step(StepPtr step)
+{
+    if (!step)
+    {
+        throw std::invalid_argument("DataList::add_step(): null step");
+    }
+    StepInfo& info = step->info();
+    ScopeInfoPtr scopeinfo = info.scopeinfo();
+    size_t scope_index = this->find_scope_index(scopeinfo);
+    size_t step_index = m_steps.size();
+    m_steps.push_back(step);
+
+    std::vector<DataInfoTuple> infos;
+    info.get_data_infos(infos);
+    for (const auto& dit : infos)
+    {
+        size_t global_index = m_datainfo.size();
+        m_equivset->insert(global_index);
+        for (size_t i = 0; i < m_datainfo.size(); ++i)
+        {
+            if (m_datainfo[i].m_scope_index == scope_index &&
+                m_datainfo[i].m_data_shortname == dit.m_shortname)
+            {
+                m_equivset->link(global_index, i);
+            }
+        }
+
+        std::vector<size_t> members;
+        m_equivset->export_one(global_index, members);
+        size_t label = global_index;
+        for (size_t m : members)
+        {
+            label = std::min(label, m);
+        }
+        for (size_t m : members)
+        {
+            if (m < m_datainfo.size())
+            {
+                m_datainfo[m].m_data_equiv_label = label;
+            }
+        }
+
+        ScopedDataInfoTuple sdit{};
+        sdit.m_wp_scopeinfo = scopeinfo;
+        sdit.m_wp_step = step;
+        sdit.m_scope_index = scope_index;
+        sdit.m_step_index = step_index;
+        sdit.m_step_data_index = dit.m_local_index;
+        sdit.m_data_equiv_label = label;
+        sdit.m_data_shortname = dit.m_shortname;
+        sdit.m_usage = dit.m_usage;
+        sdit.m_type = dit.m_type;
+        sdit.m_qualified_name =
+            info.scopename() + "." + info.shortname() + "." + dit.m_shortname;
+
+        m_datainfo.push_back(std::move(sdit));
+    }
+}
+
+size_t DataList::scope_count() const { return m_scopes.size(); }
+size_t DataList::step_count() const { return m_steps.size(); }
+size_t DataList::data_count() const { return m_datainfo.size(); }
+const std::vector<ScopePtr>& DataList::scopes() const { return m_scopes; }
+const std::vector<StepPtr>& DataList::steps() const { return m_steps; }
+const std::vector<ScopedDataInfoTuple>& DataList::datainfos() const { return m_datainfo; }
 
 } // namespace tg::core::dag

--- a/src/tg/core/dag/data_list.hpp
+++ b/src/tg/core/dag/data_list.hpp
@@ -56,7 +56,50 @@ public:
     DataList();
     ~DataList();
 
+    /**
+     * @brief Add a Scope and all its Steps to the list.
+     */
+    void add_scope(ScopePtr scope);
+
+    /**
+     * @brief Add a single Step to the list. The Step must belong to a Scope
+     *        that has been added previously.
+     */
+    void add_step(StepPtr step);
+
+    /**
+     * @brief Returns the number of scopes stored.
+     */
+    size_t scope_count() const;
+
+    /**
+     * @brief Returns the number of steps stored.
+     */
+    size_t step_count() const;
+
+    /**
+     * @brief Returns the number of data items collected.
+     */
+    size_t data_count() const;
+
+    /**
+     * @brief Access collected scopes.
+     */
+    const std::vector<ScopePtr>& scopes() const;
+
+    /**
+     * @brief Access collected steps.
+     */
+    const std::vector<StepPtr>& steps() const;
+
+    /**
+     * @brief Access collected scoped data info tuples.
+     */
+    const std::vector<ScopedDataInfoTuple>& datainfos() const;
+
 private:
+    size_t find_scope_index(ScopeInfoPtr scopeinfo) const;
+
     std::vector<ScopePtr> m_scopes;
     std::vector<StepPtr> m_steps;
     std::vector<ScopedDataInfoTuple> m_datainfo;

--- a/src/tg/testcase/data_list_testcase.cpp
+++ b/src/tg/testcase/data_list_testcase.cpp
@@ -11,6 +11,9 @@
 #include "tg/core/data_info_tuple.hpp"
 #include "tg/core/dag/data_list.hpp"
 #include "tg/core/dag/scoped_data_info_tuple.hpp"
+// demo steps
+#include "tg/core/testcase/blur_step.hpp"
+#include "tg/core/testcase/conncomp_step.hpp"
 // utilities for test running
 #include "tg/common/project_macros.hpp"
 #include "tg/testcase/ostrm.hpp"
@@ -31,7 +34,49 @@ void data_list_testcase_0(OStrm& cout)
 void data_list_testcase_1(OStrm& cout)
 {
     cout << "\n====== BEGIN data_list_testcase_1 ======\n";
-    cout << "\nWARNING: THIS TESTCASE IS NOT IMPLEMENTED YET!\n";
+    cout << "DataList collects scopes, steps and their data for binding.\n";
+    auto scope = std::make_shared<Scope>("DemoScope");
+    auto blur = std::make_shared<tg::core::testcase::BlurStep>();
+    auto conn = std::make_shared<tg::core::testcase::ConnCompStep>();
+    scope->add(blur);
+    scope->add(conn);
+
+    DataList datalist;
+    datalist.add_scope(scope);
+
+    cout << "Data items collected: " << datalist.data_count() << "\n";
+    for (size_t i = 0; i < datalist.data_count(); ++i)
+    {
+        const auto& info = datalist.datainfos().at(i);
+        cout << "(" << i << ") " << info.m_qualified_name
+             << " equiv:" << info.m_data_equiv_label << "\n";
+    }
+
+    size_t label_blur_input = 0;
+    size_t label_conn_input = 0;
+    bool found_blur = false;
+    bool found_conn = false;
+    for (const auto& info : datalist.datainfos())
+    {
+        if (info.m_data_shortname == "input" && info.m_step_index == 0)
+        {
+            label_blur_input = info.m_data_equiv_label;
+            found_blur = true;
+        }
+        if (info.m_data_shortname == "input" && info.m_step_index == 1)
+        {
+            label_conn_input = info.m_data_equiv_label;
+            found_conn = true;
+        }
+    }
+    if (found_blur && found_conn && label_blur_input == label_conn_input)
+    {
+        cout << "Equivalence label match success\n";
+    }
+    else
+    {
+        cout << "Equivalence label mismatch\n";
+    }
     cout << "\n====== END data_list_testcase_1 ======\n";
     cout << std::flush;
 }


### PR DESCRIPTION
## Summary
- flesh out DataList with APIs to add scopes and steps
- track and populate `ScopedDataInfoTuple`
- use `EquivSet` to assign equivalence labels for same-named data
- expose query helpers
- expand data_list_testcase with demo steps to verify behaviour

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "OpenCV")*

------
https://chatgpt.com/codex/tasks/task_e_6850d3ed2b58832f8b97bf94f302df75